### PR TITLE
Skip extra Apple step during build upload

### DIFF
--- a/decentraland/app.json
+++ b/decentraland/app.json
@@ -21,7 +21,10 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "io.tasit.decentraland",
-      "buildNumber": "6"
+      "buildNumber": "6",
+      "config": {
+        "usesNonExemptEncryption": false
+      }
     },
     "android": {
       "package": "io.tasit.decentraland",


### PR DESCRIPTION
<!-- Please fill out this template when opening a new PR. Thanks! -->

### Issue link

<!--- Is there an open issue for this PR? If so, please link to it.--->
n/a

### Types of changes

<!--- What type(s) of change(s) does your code introduce? Please delete any that don't apply: -->

Technical debt (a code change that doesn't fix a bug or add a feature but makes something clearer for devs)

### Notes

<!--- Any other context to be aware of when reviewing this PR -->
Now I won't have to answer two questions in the App Store Connect UI each time to say that the encryption our app uses qualifies for a standard exemption to their encryption rule