### PR TITLE
MyAccountScreen tests

### DIFF
--- a/decentraland/screens/MyAccountScreen.test.js
+++ b/decentraland/screens/MyAccountScreen.test.js
@@ -37,7 +37,7 @@ describe("MyAccountScreen", () => {
       ).toMatchSnapshot();
     });
 
-    it("funding with ethers with null action (used when action is unknowed)", async () => {
+    it("funding with ethers with null action (used when action is unknown)", async () => {
       expect(
         shallow(
           <MyAccountScreen

--- a/decentraland/screens/MyAccountScreen.test.js
+++ b/decentraland/screens/MyAccountScreen.test.js
@@ -1,11 +1,15 @@
 import React from "react";
 import { shallow } from "enzyme";
 import { MyAccountScreen } from "./MyAccountScreen";
-import AccountCreationStatus from "@constants/AccountCreationStatus";
+import {
+  FUNDING_WITH_ETH,
+  FUNDING_WITH_MANA,
+  APPROVING_MARKETPLACE,
+} from "@constants/AccountCreationStatus";
 
 describe("MyAccountScreen", () => {
   describe("renders the component", () => {
-    it("without account", async () => {
+    it("initial state (without account)", async () => {
       expect(
         shallow(
           <MyAccountScreen
@@ -18,14 +22,46 @@ describe("MyAccountScreen", () => {
       ).toMatchSnapshot();
     });
 
-    it("with account", async () => {
+    it("funding with ethers", async () => {
       expect(
         shallow(
           <MyAccountScreen
             accountInfo={{
               account: {},
               creationActions: {
-                [AccountCreationStatus.FUNDING_WITH_ETH]: {},
+                [FUNDING_WITH_ETH]: {},
+              },
+            }}
+          />
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("funding with ethers with null action (used when action is unknowed)", async () => {
+      expect(
+        shallow(
+          <MyAccountScreen
+            accountInfo={{
+              account: {},
+              creationActions: {
+                [FUNDING_WITH_ETH]: null,
+              },
+            }}
+          />
+        )
+      ).toMatchSnapshot();
+    });
+
+    it("funding with mana AND approving marketplace", async () => {
+      expect(
+        shallow(
+          <MyAccountScreen
+            accountInfo={{
+              account: {},
+              creationActions: {
+                [FUNDING_WITH_ETH]: {},
+                [FUNDING_WITH_MANA]: {},
+                [APPROVING_MARKETPLACE]: {},
               },
             }}
           />

--- a/decentraland/screens/__snapshots__/MyAccountScreen.test.js.snap
+++ b/decentraland/screens/__snapshots__/MyAccountScreen.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MyAccountScreen renders the component with account 1`] = `
+exports[`MyAccountScreen renders the component funding with ethers 1`] = `
 <MyAccount
   creationSteps={
     Array [
@@ -34,7 +34,75 @@ exports[`MyAccountScreen renders the component with account 1`] = `
 />
 `;
 
-exports[`MyAccountScreen renders the component without account 1`] = `
+exports[`MyAccountScreen renders the component funding with ethers with null action (used when action is unknowed) 1`] = `
+<MyAccount
+  creationSteps={
+    Array [
+      Object {
+        "creationStatus": "GENERATING_ACCOUNT",
+        "name": "Account created",
+        "percentage": 0.25,
+        "status": "done",
+      },
+      Object {
+        "creationStatus": "FUNDING_WITH_ETH",
+        "name": "Funded with ETH",
+        "percentage": 0.25,
+        "status": "done",
+      },
+      Object {
+        "creationStatus": "FUNDING_WITH_MANA",
+        "name": "Funded with MANA tokens",
+        "percentage": 0.25,
+        "status": "missing",
+      },
+      Object {
+        "creationStatus": "APPROVING_MARKETPLACE",
+        "name": "Linked to marketplace",
+        "percentage": 0.25,
+        "status": "missing",
+      },
+    ]
+  }
+  progress={0.5}
+/>
+`;
+
+exports[`MyAccountScreen renders the component funding with mana AND approving marketplace 1`] = `
+<MyAccount
+  creationSteps={
+    Array [
+      Object {
+        "creationStatus": "GENERATING_ACCOUNT",
+        "name": "Account created",
+        "percentage": 0.25,
+        "status": "done",
+      },
+      Object {
+        "creationStatus": "FUNDING_WITH_ETH",
+        "name": "Funded with ETH",
+        "percentage": 0.25,
+        "status": "done",
+      },
+      Object {
+        "creationStatus": "FUNDING_WITH_MANA",
+        "name": "Funded with MANA tokens",
+        "percentage": 0.25,
+        "status": "done",
+      },
+      Object {
+        "creationStatus": "APPROVING_MARKETPLACE",
+        "name": "Linked to marketplace",
+        "percentage": 0.25,
+        "status": "done",
+      },
+    ]
+  }
+  progress={1}
+/>
+`;
+
+exports[`MyAccountScreen renders the component initial state (without account) 1`] = `
 <MyAccount
   creationSteps={
     Array [

--- a/decentraland/screens/__snapshots__/MyAccountScreen.test.js.snap
+++ b/decentraland/screens/__snapshots__/MyAccountScreen.test.js.snap
@@ -34,7 +34,7 @@ exports[`MyAccountScreen renders the component funding with ethers 1`] = `
 />
 `;
 
-exports[`MyAccountScreen renders the component funding with ethers with null action (used when action is unknowed) 1`] = `
+exports[`MyAccountScreen renders the component funding with ethers with null action (used when action is unknown) 1`] = `
 <MyAccount
   creationSteps={
     Array [


### PR DESCRIPTION
<!-- Please fill out this template when opening a new PR. Thanks! -->

### Issue link

<!--- Is there an open issue for this PR? If so, please link to it.--->
https://github.com/tasitlabs/tasit/pull/315#discussion_r277054288



### Types of changes


Technical debt (a code change that doesn't fix a bug or add a feature but makes something clearer for devs)



### Notes

Here is possible to verify that "too optimistic" behavior that I've said on Slack.
When an account is funded with ethers both mana and approval steps run in parallel updating the `creationActions` state object with `FUNDING_WITH_MANA` and `APPROVING_MARKETPLACE` making the `MyAccountScreen` shows the progress as 100%.

