### PR TITLE
Prep for forcing account removal after uninstall

### DIFF
--- a/decentraland/App.js
+++ b/decentraland/App.js
@@ -69,7 +69,8 @@ Is the config file correct?`;
     // On iOS environment, Secure Store data remains even after app uninstallation
     const isFirstUse = await retrieveIsFirstUse();
     if (isFirstUse) {
-      await storeAccount(null);
+      // TODO: Uncomment this when 'isFirstUse' flag is being set widely
+      //await storeAccount(null);
       await storeIsFirstUse(false);
     }
 

--- a/decentraland/App.js
+++ b/decentraland/App.js
@@ -26,7 +26,6 @@ import {
   retrieveMyAssets,
   retrieveAccountCreationStatus,
   retrieveAccountCreationActions,
-  storeAccount,
   storeIsFirstUse,
   retrieveIsFirstUse,
 } from "@helpers/storage";

--- a/decentraland/App.js
+++ b/decentraland/App.js
@@ -26,6 +26,9 @@ import {
   retrieveMyAssets,
   retrieveAccountCreationStatus,
   retrieveAccountCreationActions,
+  storeAccount,
+  storeIsFirstUse,
+  retrieveIsFirstUse,
 } from "@helpers/storage";
 import { Ionicons } from "@expo/vector-icons";
 import { Root } from "native-base";
@@ -62,6 +65,14 @@ Is the config file correct?`;
   }
 
   async _loadAccountInfo() {
+    // Note: Forcing account removal after app uninstall
+    // On iOS environment, Secure Store data remains even after app uninstallation
+    const isFirstUse = await retrieveIsFirstUse();
+    if (isFirstUse) {
+      await storeAccount(null);
+      await storeIsFirstUse(false);
+    }
+
     const account = await retrieveAccount();
     if (account) {
       store.dispatch(setAccount(account));

--- a/decentraland/helpers/storage.js
+++ b/decentraland/helpers/storage.js
@@ -7,6 +7,19 @@ const EPHEMERAL_ACCOUNT_PRIV_KEY = "EPHEMERAL_ACCOUNT_PRIV_KEY";
 const MY_ASSETS_LIST = "MY_ASSETS_LIST";
 const EPHEMERAL_ACCOUNT_CREATION_STATUS = "EPHEMERAL_ACCOUNT_CREATION_STATUS";
 const EPHEMERAL_ACCOUNT_CREATION_ACTIONS = "EPHEMERAL_ACCOUNT_CREATION_ACTIONS";
+const APP_IS_FIRST_USE = "APP_IS_FIRST_USE";
+
+export const storeIsFirstUse = async isFirstUse => {
+  const strIsFirstUse = _toString(isFirstUse);
+  await _storeData(APP_IS_FIRST_USE, strIsFirstUse, false);
+};
+
+export const retrieveIsFirstUse = async () => {
+  const strIsFirstUse = await _retrieveData(APP_IS_FIRST_USE);
+  const isFirstUse = _fromString(strIsFirstUse);
+  if (isFirstUse === null) return true;
+  return isFirstUse;
+};
 
 export const storeAccountCreationActions = async creationActions => {
   const strCreationActions = _toString(creationActions);
@@ -19,8 +32,7 @@ export const storeAccountCreationActions = async creationActions => {
 
 export const retrieveAccountCreationActions = async () => {
   const strCreationActions = await _retrieveData(
-    EPHEMERAL_ACCOUNT_CREATION_ACTIONS,
-    false
+    EPHEMERAL_ACCOUNT_CREATION_ACTIONS
   );
   let creationActions = _fromString(strCreationActions);
   return creationActions;
@@ -31,7 +43,7 @@ export const storeAccountCreationStatus = async status => {
 };
 
 export const retrieveAccountCreationStatus = async () => {
-  const status = await _retrieveData(EPHEMERAL_ACCOUNT_CREATION_STATUS, false);
+  const status = await _retrieveData(EPHEMERAL_ACCOUNT_CREATION_STATUS);
   return status;
 };
 
@@ -43,7 +55,7 @@ export const storeAccount = async account => {
 export const retrieveAccount = async () => {
   let account = null;
 
-  const privateKey = await _retrieveData(EPHEMERAL_ACCOUNT_PRIV_KEY, true);
+  const privateKey = await _retrieveData(EPHEMERAL_ACCOUNT_PRIV_KEY);
   if (privateKey != null) account = createFromPrivateKey(privateKey);
 
   return account;
@@ -55,7 +67,7 @@ export const storeMyAssets = async myAssets => {
 };
 
 export const retrieveMyAssets = async () => {
-  const strMyAssets = await _retrieveData(MY_ASSETS_LIST, false);
+  const strMyAssets = await _retrieveData(MY_ASSETS_LIST);
   let myAssets = _fromString(strMyAssets);
   if (!myAssets) myAssets = [];
   return myAssets;
@@ -93,18 +105,14 @@ const _storeData = async (key, value, securely) => {
   }
 };
 
-const _retrieveData = async (key, securely) => {
+const _retrieveData = async key => {
   try {
-    let value = null;
-
-    if (securely) value = await SecureStore.getItemAsync(key);
-    else value = await AsyncStorage.getItem(key);
+    let value = await AsyncStorage.getItem(key);
+    if (value === null) value = await SecureStore.getItemAsync(key);
 
     return value;
   } catch (error) {
-    throw Error(
-      `Unable to ${securely ? "securely" : ""} retrieve data from storage.`
-    );
+    throw Error(`Unable to retrieve data from storage.`);
   }
 };
 
@@ -117,4 +125,6 @@ export default {
   retrieveAccountCreationStatus,
   storeAccountCreationActions,
   retrieveAccountCreationActions,
+  storeIsFirstUse,
+  retrieveIsFirstUse,
 };

--- a/decentraland/helpers/storage.js
+++ b/decentraland/helpers/storage.js
@@ -7,15 +7,15 @@ const EPHEMERAL_ACCOUNT_PRIV_KEY = "EPHEMERAL_ACCOUNT_PRIV_KEY";
 const MY_ASSETS_LIST = "MY_ASSETS_LIST";
 const EPHEMERAL_ACCOUNT_CREATION_STATUS = "EPHEMERAL_ACCOUNT_CREATION_STATUS";
 const EPHEMERAL_ACCOUNT_CREATION_ACTIONS = "EPHEMERAL_ACCOUNT_CREATION_ACTIONS";
-const APP_IS_FIRST_USE = "APP_IS_FIRST_USE";
+const IS_FIRST_APP_USE = "IS_FIRST_APP_USE";
 
 export const storeIsFirstUse = async isFirstUse => {
   const strIsFirstUse = _toString(isFirstUse);
-  await _storeData(APP_IS_FIRST_USE, strIsFirstUse, false);
+  await _storeData(IS_FIRST_APP_USE, strIsFirstUse, false);
 };
 
 export const retrieveIsFirstUse = async () => {
-  const strIsFirstUse = await _retrieveData(APP_IS_FIRST_USE);
+  const strIsFirstUse = await _retrieveData(IS_FIRST_APP_USE);
   const isFirstUse = _fromString(strIsFirstUse);
   if (isFirstUse === null) return true;
   return isFirstUse;

--- a/decentraland/helpers/storage.js
+++ b/decentraland/helpers/storage.js
@@ -48,7 +48,7 @@ export const retrieveAccountCreationStatus = async () => {
 };
 
 export const storeAccount = async account => {
-  const { privateKey } = account;
+  const privateKey = account !== null ? account.privateKey : null;
   await _storeData(EPHEMERAL_ACCOUNT_PRIV_KEY, privateKey, true);
 };
 


### PR DESCRIPTION
<!-- Please fill out this template when opening a new PR. Thanks! -->

### Issue link

<!--- Is there an open issue for this PR? If so, please link to it.--->
https://github.com/tasitlabs/tasit/pull/298#discussion_r276225655
#295 

### Auto-close the issue?

<!---
If this PR should close the associated issue when it's merged, please change XXX below to the issue number.
Otherwise, you can remove this section.
--->

Closes #295

### Types of changes

New feature (non-breaking change that adds functionality)


### Notes

The way that it is, all accounts will be removed because none of them have the param `isFirstUse` stored yet.
Maybe we can introduce `storeIsFirstUse(false);` only for now and check this var (and remove account) later? Any better idea?

